### PR TITLE
Simple syntax fix in budget controller

### DIFF
--- a/app/controllers/deliverables_controller.rb
+++ b/app/controllers/deliverables_controller.rb
@@ -151,13 +151,13 @@ class DeliverablesController < ApplicationController
   def sort_if_needed(deliverables)
     if session[@sort_name] && %w(score spent progress labor_budget).include?(session[@sort_name][:key])
       case session[@sort_name][:key]
-      when "score":
+      when "score"
           sorted = deliverables.sort {|a,b| a.score <=> b.score}
-      when "spent":
+      when "spent"
           sorted = deliverables.sort {|a,b| a.spent <=> b.spent}
-      when "progress":
+      when "progress"
           sorted = deliverables.sort {|a,b| a.progress <=> b.progress}
-      when "labor_budget":
+      when "labor_budget"
           sorted = deliverables.sort {|a,b| a.labor_budget <=> b.labor_budget}
       end
 


### PR DESCRIPTION
Removed colons (:) from when statements in  case session[@sort_name][:key] @ lines 154-160 for compatibility with Chiliproject 3.0.0 in 1.9.2. Nothing complex, tested and working.
